### PR TITLE
Add PlatformIO library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,11 @@
+{
+  "name": "TFT 22 ILI9225",
+  "description": "Arduino driver for the ILI9225 based TFT with SPI Interface",
+  "keywords": "tft,22,lcd",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Nkawu/TFT_22_ILI9225.git"
+  },
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}


### PR DESCRIPTION
This would allow this library to appear in the [PlatformIO library manager](http://docs.platformio.org/en/latest/librarymanager/). I've looked through the [`library.json` spec](http://docs.platformio.org/en/latest/librarymanager/config.html) and added everything that I can think of.