### PR TITLE
Using FAST_PINIO on dual-core ESP32 is causing fatal errorsdue to si…

### DIFF
--- a/src/TFT_22_ILI9225.h
+++ b/src/TFT_22_ILI9225.h
@@ -144,9 +144,9 @@ struct _currentFont
 };
 #define MONOSPACE   1
 
-#if defined (ARDUINO_STM32_FEATHER)
+#if defined (ARDUINO_STM32_FEATHER) || defined(ESP32)
     #undef USE_FAST_PINIO
-#elif defined (__AVR__) || defined(TEENSYDUINO) || defined(ESP8266) || defined (ESP32) || defined(__arm__)
+#elif defined (__AVR__) || defined(TEENSYDUINO) || defined(ESP8266) || defined(__arm__)
     #define USE_FAST_PINIO
 #endif
 


### PR DESCRIPTION
due to side effects. The operations on the port are non-atomic, and can have unwanted and unexpected side effects on software running on the other CPU core if this software also accesses IO ports.

In addition, FAST_PINIO is also not fast on ESP32. My reference board (T-Beam v1.0)
takes 2.48s to flip a pin 10e7 times with digitalWrite(pin, ON); digitalWrite(pin, OFF).
It takes 2.52s to flip the same pin 10e7 times with *pin |= pinmask; *pin &= ~pinmask.

So this modification causes a slight speed-up and removes a serious problem.